### PR TITLE
Adding foreign key to Game model instead of has_many  association

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,4 +1,7 @@
 class Game < ApplicationRecord
   has_many	:pieces
 
+  belongs_to :white_player, :class_name => 'User', :foreign_key => 'white_player_id'
+  belongs_to :black_player, :class_name => 'User', :foreign_key => 'black_player_id'
+
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,4 +1,4 @@
 class Game < ApplicationRecord
   has_many	:pieces
-  has_many	:users
+
 end

--- a/db/migrate/20171110082023_add_blackplayer_id_and_whiteplayer_id_to_users.rb
+++ b/db/migrate/20171110082023_add_blackplayer_id_and_whiteplayer_id_to_users.rb
@@ -1,0 +1,9 @@
+class AddBlackplayerIdAndWhiteplayerIdToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :users, :white_player
+    add_reference :users, :black_player
+
+    add_foreign_key :users, :games, column: :white_player_id
+    add_foreign_key :users, :games, column: :black_player_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema.define(version: 20171108063401) do
+ActiveRecord::Schema.define(version: 20171110082023) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "games", force: :cascade do |t|
+    t.integer  "game_id"
+    t.integer  "white_player_id"
+    t.integer  "black_player_id"
+    t.integer  "result"
+    t.integer  "winner_id"
+    t.integer  "loser_id"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+  end
 
   create_table "pieces", force: :cascade do |t|
     t.integer  "piece_id"
@@ -26,7 +36,6 @@ ActiveRecord::Schema.define(version: 20171108063401) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
-
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                  default: "", null: false
@@ -42,19 +51,14 @@ ActiveRecord::Schema.define(version: 20171108063401) do
     t.datetime "created_at",                          null: false
     t.datetime "updated_at",                          null: false
     t.string   "name"
-    t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
-  end
-
-  create_table "games", force: :cascade do |t|
-    t.integer  "game_id"
     t.integer  "white_player_id"
     t.integer  "black_player_id"
-    t.integer  "result"
-    t.integer  "winner_id"
-    t.integer  "loser_id"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+    t.index ["black_player_id"], name: "index_users_on_black_player_id", using: :btree
+    t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
+    t.index ["white_player_id"], name: "index_users_on_white_player_id", using: :btree
   end
 
+  add_foreign_key "users", "games", column: "black_player_id"
+  add_foreign_key "users", "games", column: "white_player_id"
 end


### PR DESCRIPTION
Tried to add foreign key as per Ilya's comment: https://github.com/sudo-chess/chess-app/pull/2
- Removed the has_many :players from the Game model
- created a migration with add_reference and foreign_key, ran it

If you look at schema.rb, it now shows two fields black_player_id and white_player_id, which I assume are the foreign keys created (along with some indexes).

I am absolutely not sure this is correct, but it's my attempt to do it, so don't merge this into master as it is more for reviewing purpose for now..