### PR TITLE
Promotion: allowing user to choose in which type of piece to promote.

### DIFF
--- a/app/assets/javascripts/games.js
+++ b/app/assets/javascripts/games.js
@@ -32,16 +32,19 @@ $( function() {
       // var origX = ui.draggable.parent().data('position_x');
       // var origY = ui.draggable.parent().data('position_y');
 
-      var destX = $(this).parent().data('position_x')
-      var destY = $(this).parent().data('position_y')
+      var destX = $(this).parent().data('position_x');
+      var destY = $(this).parent().data('position_y');
 
-      var pieceId = ui.draggable.parent().data('piece-id')
+      var pieceId = ui.draggable.parent().data('piece-id');
+      var type = ui.draggable.parent().data('type');
+      console.log(type);
 
       // var piece = {piece: {position_x: origX, position_y: origY, id: pieceId}};
-      var target = {piece: {position_x : destX, position_y: destY, id: pieceId}};
+      // var target = {piece: {position_x : destX, position_y: destY, id: pieceId, promo: "promo"}};
 
       var modal = document.getElementById('myModal');
       var span = document.getElementsByClassName("close")[0];
+      var promo = "";
 
       if (destY == 4) {
          modal.style.display = "block";
@@ -57,20 +60,69 @@ $( function() {
           }
          }
 
+
+
+          var form = document.querySelector("form");
+          var log = document.querySelector("#log");
+
+          form.addEventListener("submit", function(event) {
+            var data = new FormData(form);
+            var output = "";
+            for (const entry of data) {
+              // output = entry[0] + "=" + entry[1] + "\r";
+              promo = entry[1];
+            };
+            console.log(promo);
+
+
+
+        var target = {piece: {position_x : destX, position_y: destY, id: pieceId, promo: promo}};
+
+        if (promo === "Queen"){
+          console.log("yahoooo!");
+
+          $.ajax({
+            type: 'PUT',
+            url: '/pieces/update/',
+            headers: {
+            'X-CSRF-Token': $("meta[name='csrf-token']").attr("content")
+              },
+            dataType: 'json',
+            data: target
+          })
+        }
+
+
+
+        if (promo === "Rook"){
+        console.log("yahoooo!");
+
+
+        }
+
+
+            // log.innerText = output;
+            event.preventDefault();
+            modal.style.display = "none";
+          }, false);
+
+
+         
+
       }
+      
+     
+      //  $.ajax({
+      //   type: 'PUT',
+      //   url: '/pieces/update/',
+      //   headers: {
+      //   'X-CSRF-Token': $("meta[name='csrf-token']").attr("content")
+      //     },
+      //   dataType: 'json',
+      //   data: target
+      // })
 
-
-       $.ajax({
-        type: 'PUT',
-        url: '/pieces/update/',
-        headers: {
-        'X-CSRF-Token': $("meta[name='csrf-token']").attr("content")
-          },
-        dataType: 'json',
-        data: target
-      })
-
-      location.reload();
+      // location.reload();
     }
   });
   // console.log(move_player)

--- a/app/assets/javascripts/games.js
+++ b/app/assets/javascripts/games.js
@@ -46,10 +46,8 @@ $( function() {
       var span = document.getElementsByClassName("close")[0];
       var promo = "";
 
-      if (destY == 4) {
+      if (destY === 8 || destY === 1 && type === 'Pawn') {
          modal.style.display = "block";
-
-
 
          span.onclick = function() {
           modal.style.display = "none";
@@ -60,67 +58,53 @@ $( function() {
           }
          }
 
+        var form = document.querySelector("form");
+        var log = document.querySelector("#log");
 
-
-          var form = document.querySelector("form");
-          var log = document.querySelector("#log");
-
-          form.addEventListener("submit", function(event) {
-            var data = new FormData(form);
-            var output = "";
-            for (const entry of data) {
-              // output = entry[0] + "=" + entry[1] + "\r";
-              promo = entry[1];
-            };
-            console.log(promo);
-
-
+        form.addEventListener("submit", function(event) {
+          var data = new FormData(form);
+          var output = "";
+          for (const entry of data) {
+            // output = entry[0] + "=" + entry[1] + "\r";
+            promo = entry[1];
+          };
 
         var target = {piece: {position_x : destX, position_y: destY, id: pieceId, promo: promo}};
 
-        if (promo === "Queen"){
-          console.log("yahoooo!");
-
-          $.ajax({
-            type: 'PUT',
-            url: '/pieces/update/',
-            headers: {
-            'X-CSRF-Token': $("meta[name='csrf-token']").attr("content")
-              },
-            dataType: 'json',
-            data: target
-          })
-        }
-
-
-
-        if (promo === "Rook"){
-        console.log("yahoooo!");
-
-
-        }
-
-
+     
+        $.ajax({
+          type: 'PUT',
+          url: '/pieces/update/',
+          headers: {
+          'X-CSRF-Token': $("meta[name='csrf-token']").attr("content")
+            },
+          dataType: 'json',
+          data: target
+        })
+        
             // log.innerText = output;
             event.preventDefault();
             modal.style.display = "none";
           }, false);
 
+      }
 
-         
+      else {
+        // promo = ""
+        var target = {piece: {position_x : destX, position_y: destY, id: pieceId, promo: promo}};
+
+        $.ajax({
+          type: 'PUT',
+          url: '/pieces/update/',
+          headers: {
+          'X-CSRF-Token': $("meta[name='csrf-token']").attr("content")
+            },
+          dataType: 'json',
+          data: target
+        })
 
       }
-      
-     
-      //  $.ajax({
-      //   type: 'PUT',
-      //   url: '/pieces/update/',
-      //   headers: {
-      //   'X-CSRF-Token': $("meta[name='csrf-token']").attr("content")
-      //     },
-      //   dataType: 'json',
-      //   data: target
-      // })
+         
 
       // location.reload();
     }

--- a/app/assets/javascripts/games.js
+++ b/app/assets/javascripts/games.js
@@ -46,12 +46,12 @@ $( function() {
       var span = document.getElementsByClassName("close")[0];
       var promo = "";
 
-      if (destY === 8 || destY === 1 && type === 'Pawn') {
+      if (destY === 8 && type === 'Pawn' || destY === 1 && type === 'Pawn') {
          modal.style.display = "block";
 
-         span.onclick = function() {
-          modal.style.display = "none";
-         }
+         // span.onclick = function() {
+         //  modal.style.display = "none";
+         // }
          window.onclick = function(event) {
           if (event.target == modal) {
           modal.style.display = "none";
@@ -90,7 +90,6 @@ $( function() {
       }
 
       else {
-        // promo = ""
         var target = {piece: {position_x : destX, position_y: destY, id: pieceId, promo: promo}};
 
         $.ajax({
@@ -103,11 +102,8 @@ $( function() {
           data: target
         })
 
+      location.reload();
       }
-         
-
-      // location.reload();
     }
   });
-  // console.log(move_player)
 });

--- a/app/assets/javascripts/games.js
+++ b/app/assets/javascripts/games.js
@@ -40,8 +40,25 @@ $( function() {
       // var piece = {piece: {position_x: origX, position_y: origY, id: pieceId}};
       var target = {piece: {position_x : destX, position_y: destY, id: pieceId}};
 
+      var modal = document.getElementById('myModal');
+      var span = document.getElementsByClassName("close")[0];
 
-      
+      if (destY == 4) {
+         modal.style.display = "block";
+
+
+
+         span.onclick = function() {
+          modal.style.display = "none";
+         }
+         window.onclick = function(event) {
+          if (event.target == modal) {
+          modal.style.display = "none";
+          }
+         }
+
+      }
+
 
        $.ajax({
         type: 'PUT',

--- a/app/assets/stylesheets/games.scss
+++ b/app/assets/stylesheets/games.scss
@@ -101,6 +101,15 @@ height: 100%;
   clear: both;
 } 
 
+.center {
+    margin: auto;
+    width: 33%;
+}
+
+.promo {
+  text-align: center;
+  margin-left: 50px;
+}
 
 /* The Modal (background) */
 .modal {

--- a/app/assets/stylesheets/games.scss
+++ b/app/assets/stylesheets/games.scss
@@ -101,3 +101,42 @@ height: 100%;
   clear: both;
 } 
 
+
+/* The Modal (background) */
+.modal {
+    display: none; /* Hidden by default */
+    position: fixed; /* Stay in place */
+    z-index: 1; /* Sit on top */
+    left: 0;
+    top: 0;
+    width: 100%; /* Full width */
+    height: 100%; /* Full height */
+    overflow: auto; /* Enable scroll if needed */
+    background-color: rgb(0,0,0); /* Fallback color */
+    background-color: rgba(0,0,0,0.4); /* Black w/ opacity */
+}
+
+/* Modal Content/Box */
+.modal-content {
+    background-color: #fefefe;
+    margin: 15% auto; /* 15% from the top and centered */
+    padding: 20px;
+    border: 1px solid #888;
+    width: 80%; /* Could be more or less, depending on screen size */
+}
+
+/* The Close Button */
+.close {
+    color: #aaa;
+    float: right;
+    font-size: 28px;
+    font-weight: bold;
+}
+
+.close:hover,
+.close:focus {
+    color: black;
+    text-decoration: none;
+    cursor: pointer;
+}
+

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -13,10 +13,6 @@ class PiecesController < ApplicationController
   end
 
   def update
-      puts "............."
-      puts params
-
-
       @current_piece = Piece.find_by_id(piece_params[:id])
 
       @local_game_id = @current_piece.game_id
@@ -32,10 +28,12 @@ class PiecesController < ApplicationController
 
       
       if @current_piece.valid_move?(@target_x, @target_y)
+
         @current_piece.move_to!(@target_x, @target_y, @promo)
+
         king = @local_game.pieces.where(type: "King", color: @current_piece.color)[0]
         if king.is_in_check? == true
-          @current_piece.move_to!(@old_x, @old_y)
+          @current_piece.move_to!(@old_x, @old_y, @promo)
           if @target != nil
             @revert = Piece.find_by(id: @target.id)
             @revert.update_attributes!(position_x: @target_x, position_y: @target_y)

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -8,7 +8,15 @@ class PiecesController < ApplicationController
       @current_piece = Piece.find_by_id(params[:id])
   end
 
+  def promote
+
+  end
+
   def update
+      puts "............."
+      puts params
+
+
       @current_piece = Piece.find_by_id(piece_params[:id])
 
       @local_game_id = @current_piece.game_id
@@ -17,12 +25,14 @@ class PiecesController < ApplicationController
 
       @target_x = piece_params[:position_x].to_i
       @target_y = piece_params[:position_y].to_i
+      @promo = piece_params[:promo]
       @target = @local_game.pieces.where(position_x: @target_x, position_y: @target_y).first
       @old_x = @current_piece.position_x
       @old_y = @current_piece.position_y
+
       
       if @current_piece.valid_move?(@target_x, @target_y)
-        @current_piece.move_to!(@target_x, @target_y)
+        @current_piece.move_to!(@target_x, @target_y, @promo)
         king = @local_game.pieces.where(type: "King", color: @current_piece.color)[0]
         if king.is_in_check? == true
           @current_piece.move_to!(@old_x, @old_y)
@@ -43,6 +53,6 @@ class PiecesController < ApplicationController
 
 private
   def piece_params
-      params.require(:piece).permit(:id, :position_x, :position_y)
+      params.require(:piece).permit(:id, :position_x, :position_y, :promo)
   end
 end

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -13,6 +13,9 @@ class PiecesController < ApplicationController
   end
 
   def update
+
+      puts "......................................................................"
+      puts params
       @current_piece = Piece.find_by_id(piece_params[:id])
       @local_game_id = @current_piece.game_id
       @local_game = Game.find(@local_game_id)
@@ -27,7 +30,7 @@ class PiecesController < ApplicationController
 
       
       if @current_piece.valid_move?(@target_x, @target_y)
-
+        
         @current_piece.move_to!(@target_x, @target_y, @promo)
 
         king = @local_game.pieces.where(type: "King", color: @current_piece.color)[0]
@@ -44,7 +47,7 @@ class PiecesController < ApplicationController
         flash[:notice] = "That was not a valid move"  
       end
       @local_game.reload
-      sleep(6)
+      # sleep(6)
       redirect_to game_path(@local_game_id) 
   end
 

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -14,7 +14,6 @@ class PiecesController < ApplicationController
 
   def update
       @current_piece = Piece.find_by_id(piece_params[:id])
-
       @local_game_id = @current_piece.game_id
       @local_game = Game.find(@local_game_id)
       @local_pieces = @local_game.pieces

--- a/app/helpers/games_helper.rb
+++ b/app/helpers/games_helper.rb
@@ -13,10 +13,6 @@ module GamesHelper
         end
       end
     end
-
-    # return link_to '', piece_path(@current_piece.id, position_x: x, position_y: y), :method => :put, :class => "square", :id => "droppable"
-    # return   :class => "square", :id => "droppable"
-    # return  content_tag("rrr") :div, class: "square", id: "droppable"
     return  content_tag(:div, "", class: "square")
 
     

--- a/app/models/bishop.rb
+++ b/app/models/bishop.rb
@@ -14,7 +14,8 @@ class Bishop < Piece
  
 
  def diagonal_move?(x,y)
-    (self.position_x.to_i-x.to_i).abs == (self.position_y.to_i-y.to_i).abs
+
+    (position_x.to_i-x.to_i).abs == (position_y.to_i-y.to_i).abs
  end
 
 end

--- a/app/models/knight.rb
+++ b/app/models/knight.rb
@@ -8,6 +8,7 @@ class Knight < Piece
   end  
 
   def valid_move?(x,y)
+    if self.position_x != nil
     valid_moves = [
       [self.position_x+1,self.position_y+2], 
       [self.position_x+2,self.position_y+1], 
@@ -19,6 +20,7 @@ class Knight < Piece
       [self.position_x-1,self.position_y+2]]
    
     return valid_moves.include?([x.to_i,y.to_i]) && is_on_board?(x,y)
+    end
   end
 
 end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -20,7 +20,14 @@ class Pawn < Piece
       Queen.create(game_id: game.id, position_x: x, position_y: y, color: self.color, :image => Queen.get_image(color))
     elsif promo == "Rook"
       Rook.create(game_id: game.id, position_x: x, position_y: y, color: self.color, :image => Rook.get_image(color))
+    elsif promo == "Bishop"
+      Bishop.create(game_id: game.id, position_x: x, position_y: y, color: self.color, :image => Bishop.get_image(color))
+    elsif promo == "Knight"
+      Knight.create(game_id: game.id, position_x: x, position_y: y, color: self.color, :image => Knight.get_image(color))
+    elsif promo == nil
+      Pawn.create(game_id: game.id, position_x: x, position_y: y, color: self.color, :image => Pawn.get_image(color))
     end
+
   end
 
 

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -24,7 +24,7 @@ class Pawn < Piece
       Bishop.create(game_id: game.id, position_x: x, position_y: y, color: self.color, :image => Bishop.get_image(color))
     elsif promo == "Knight"
       Knight.create(game_id: game.id, position_x: x, position_y: y, color: self.color, :image => Knight.get_image(color))
-    elsif promo == ""
+    elsif promo == "" || promo == nil
       Pawn.create(game_id: game.id, position_x: x, position_y: y, color: self.color, :image => Pawn.get_image(color))
     end
 

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -13,7 +13,7 @@ class Pawn < Piece
   end
 
 
-  def promotion(x,y,promo)  
+  def promotion(x,y,promo) 
     game = self.game
     self.update_attributes(position_x: nil, position_y: nil)
     if promo == "Queen"
@@ -24,7 +24,7 @@ class Pawn < Piece
       Bishop.create(game_id: game.id, position_x: x, position_y: y, color: self.color, :image => Bishop.get_image(color))
     elsif promo == "Knight"
       Knight.create(game_id: game.id, position_x: x, position_y: y, color: self.color, :image => Knight.get_image(color))
-    elsif promo == nil
+    elsif promo == ""
       Pawn.create(game_id: game.id, position_x: x, position_y: y, color: self.color, :image => Pawn.get_image(color))
     end
 

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -13,10 +13,14 @@ class Pawn < Piece
   end
 
 
-  def promotion(x,y)  
+  def promotion(x,y,promo)  
     game = self.game
     self.update_attributes(position_x: nil, position_y: nil)
-    Queen.create(game_id: game.id, position_x: x, position_y: y, color: self.color, :image => Queen.get_image(color))
+    if promo == "Queen"
+      Queen.create(game_id: game.id, position_x: x, position_y: y, color: self.color, :image => Queen.get_image(color))
+    elsif promo == "Rook"
+      Rook.create(game_id: game.id, position_x: x, position_y: y, color: self.color, :image => Rook.get_image(color))
+    end
   end
 
 

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -22,7 +22,7 @@ class Piece < ApplicationRecord
     end
 
     #cases for pawn promotion
-    if @target == nil && self.color == "white" && new_y == 4 && self.type == "Pawn"
+    if @target == nil && self.color == "white" && new_y == 8 && self.type == "Pawn"
       self.promotion(new_x, new_y, promo)
     elsif @target == nil && self.color == "black"  && new_y == 1 && self.type == "Pawn"
       self.promotion(new_x, new_y, promo)

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -9,7 +9,7 @@ class Piece < ApplicationRecord
     occupied_positions
   end
 
-   def move_to!(new_x, new_y, promo)
+   def move_to!(new_x, new_y, promo = nil)
     @current_game = self.game
     @target = @current_game.pieces.where(position_x: new_x, position_y: new_y)[0]
 

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -95,13 +95,24 @@ class Piece < ApplicationRecord
 
 
   def is_diagonally_obstructed?(pos1,pos2)
+      x1, y1 = @x1, @y1
+      x2, y2 = @x2, @y2
     if (@x1-@x2).abs == (@y1-@y2).abs
       @x1 , @x2 = @x2 , @x1 if @x1 > @x2
       @y1 , @y2 = @y2 , @y1 if @y1 > @y2
 
       x_ary = (@x1+1...@x2).to_a
       y_ary = (@y1+1...@y2).to_a
-      @squares_to_check = x_ary.zip(y_ary)
+
+      if x1 > x2 && y1 < y2
+        x_ary.reverse!
+        @squares_to_check = x_ary.zip(y_ary)
+      elsif x1 < x2 && y1 > y2
+        y_ary.reverse!
+        @squares_to_check = x_ary.zip(y_ary)
+      else 
+        @squares_to_check = x_ary.zip(y_ary)
+      end
 
     check_squares
     end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -9,7 +9,7 @@ class Piece < ApplicationRecord
     occupied_positions
   end
 
-   def move_to!(new_x, new_y)
+   def move_to!(new_x, new_y, promo)
     @current_game = self.game
     @target = @current_game.pieces.where(position_x: new_x, position_y: new_y)[0]
 
@@ -22,16 +22,16 @@ class Piece < ApplicationRecord
     end
 
     #cases for pawn promotion
-    if @target == nil && self.color == "white" && new_y == 8 && self.type == "Pawn"
-      self.promotion(new_x, new_y)
+    if @target == nil && self.color == "white" && new_y == 4 && self.type == "Pawn"
+      self.promotion(new_x, new_y, promo)
     elsif @target == nil && self.color == "black"  && new_y == 1 && self.type == "Pawn"
-      self.promotion(new_x, new_y)
+      self.promotion(new_x, new_y, promo)
     elsif self.color == "white"  && new_y == 8 && self.type == "Pawn"
       @target.update_attributes!(position_x: nil, position_y: nil)
-      self.promotion(new_x, new_y)
+      self.promotion(new_x, new_y, promo)
     elsif self.color == "black" && new_y == 1 && self.type == "Pawn"
       @target.update_attributes!(position_x: nil, position_y: nil)
-      self.promotion(new_x, new_y)
+      self.promotion(new_x, new_y, promo)
     #in case on piece on destination
     elsif @target == nil
       self.update_attributes!(position_x: new_x, position_y: new_y, moved: true)

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -55,3 +55,80 @@
   </div>
 <% end %>
 
+<div id="myModal" class="modal" method="post">
+  <div class="modal-content">
+
+    <span class="close">CLOSE</span>
+    <form id="myForm" action="#" > 
+
+      <input type="radio"  name="rtype" value="Rook"> Rook<br>
+      <input type="radio"  name="qtype" value="Queen"> Queen<br>
+      <input type="radio"  name="btype" value="Bishop"> Bishop <br>
+      <input type="radio"  name="ktype" value="Knight"> Knight <br>
+          <input type="submit" value="Submit">
+      Choose<input type="text" name="fname" value="Donald"><br>
+      Rook: <input type="text" name="fname" value="Duck"><br><br>
+     <button onclick="myFunction()">Promote!</button> 
+
+    </form>
+  </div>
+</div>
+
+
+<!--  <div id="myModal" class="modal" method="post">
+  <div class="modal-content">
+    <span class="close">CLOSE</span>
+    <form id="myForm">
+      <p>Veuillez choisir la meilleure méthode pour vous contacter :</p>
+      <div>
+        <input type="radio" id="promoChoice1"
+         name="contact" value="Queen">
+        <label for="promoChoice1">Queen</label>
+
+        <input type="radio" id="promoChoice2"
+         name="contact" value="Rook">
+        <label for="promoChoice2">Rook</label>
+
+        <input type="radio" id="promoChoice3"
+         name="contact" value="Bishop">
+        <label for="promoChoice3">Bishop</label>
+
+        <input type="radio" id="promoChoice4"
+         name="contact" value="Knight">
+        <label for="promoChoice4">Knight</label>
+
+
+      </div>
+      <div>
+        <button type="submit">Envoyer</button>
+      </div>
+    </form>
+ </div>
+</div> -->
+
+
+<pre id="log">
+</pre>
+
+
+<script>
+var form = document.querySelector("form");
+var log = document.querySelector("#log");
+
+form.addEventListener("submit", function(event) {
+  var data = new FormData(form);
+  var output = "";
+  for (const entry of data) {
+    // output = entry[0] + "=" + entry[1] + "\r";
+    promo = entry[1];
+  };
+  console.log(promo);
+  log.innerText = output;
+  event.preventDefault();
+}, false);
+</script>
+
+
+
+
+

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -56,58 +56,66 @@
 <% end %>
 
 
- <div id="myModal" class="modal" method="post">
+ <div id="myModal" class="modal" method="post" style="text-align: center;">
   <div class="modal-content">
-    <span class="close">CLOSE</span>
+    
+    
+    <!-- <span class="close">CLOSE</span> -->
     <form id="myForm">
-      <p>Veuillez choisir la meilleure méthode pour vous contacter :</p>
-      <div>
-        <input type="radio" id="promoChoice1"
-         name="contact" value="Queen">
-        <label for="promoChoice1">Queen </label>
-
-        <input type="radio" id="promoChoice2"
-         name="contact" value="Rook">
-        <label for="promoChoice2">Rook</label>
-
-        <input type="radio" id="promoChoice3"
-         name="contact" value="Bishop">
-        <label for="promoChoice3">Bishop</label>
-
-        <input type="radio" id="promoChoice4"
-         name="contact" value="Knight">
-        <label for="promoChoice4">Knight</label>
-
+      <h3>Choose your promotion:</h3>
+      <h5>If you don't make any choice your pawn will not promote and remain.. a pawn!</h5>
+      <h5>Click anywhere out of the box to make another move instead</h5>
+      <br/>
+      <div class="row center" style="text-align: center";>
+        
+        <div class="promo">
+          <% if @local_game.next_player_id == @local_game.white_player.id %>
+            <%= image_tag('chess_piece_queen_white.png', :class=>"img-responsive white-piece")%><br/>
+          <% else %>
+            <%= image_tag('chess_piece_queen_black.png', :class=>"img-responsive white-piece")%><br/>
+          <% end %>
+          <input type="radio" id="promoChoice1" name="contact" value="Queen">
+          <label for="promoChoice1">Queen </label> <br/> 
+        </div>
+       
+         <div class="promo">
+            <% if @local_game.next_player_id == @local_game.white_player.id %>
+            <%= image_tag('chess_piece_rook_white.png', :class=>"img-responsive white-piece")%><br/>
+          <% else %>
+            <%= image_tag('chess_piece_rook_black.png', :class=>"img-responsive white-piece")%><br/>
+          <% end %>
+          <input type="radio" id="promoChoice1" name="contact" value="Rook">
+          <label for="promoChoice1">Rook </label> <br/> 
+        </div class="center">
+      
+         <div class="promo">
+            <% if @local_game.next_player_id == @local_game.white_player.id %>
+            <%= image_tag('chess_piece_bishop_white.png', :class=>"img-responsive white-piece")%><br/>
+          <% else %>
+            <%= image_tag('chess_piece_bishop_black.png', :class=>"img-responsive white-piece")%><br/>
+          <% end %>
+          <input type="radio" id="promoChoice1" name="contact" value="Bishop">
+          <label for="promoChoice1">Bishop </label> <br/> 
+        </div>
+        
+        <div class="promo">
+          <% if @local_game.next_player_id == @local_game.white_player.id %>
+            <%= image_tag('chess_piece_knight_white.png', :class=>"img-responsive white-piece")%><br/>
+          <% else %>
+            <%= image_tag('chess_piece_knight_black.png', :class=>"img-responsive white-piece")%><br/>
+          <% end %>
+          <input type="radio" id="promoChoice1" name="contact" value="Knight">
+          <label for="promoChoice1">Knight </label> <br/> 
+        </div>
 
       </div>
       <div>
-        <button type="submit">Envoyer</button>
+        <button type="submit">PROMOTE!</button>
       </div>
     </form>
  </div>
 </div>
 
-
-
-
-<script>
-// var form = document.querySelector("form");
-// var log = document.querySelector("#log");
-// var modal = document.getElementById('myModal');
-
-// form.addEventListener("submit", function(event) {
-//   var data = new FormData(form);
-//   var output = "";
-//   for (const entry of data) {
-//     // output = entry[0] + "=" + entry[1] + "\r";
-//     promo = entry[1];
-//   };
-//   console.log(promo);
-//   // log.innerText = output;
-//   event.preventDefault();
-//   modal.style.display = "none";
-// }, false);
-</script>
 
 
 

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -64,7 +64,7 @@
       <div>
         <input type="radio" id="promoChoice1"
          name="contact" value="Queen">
-        <label for="promoChoice1">Queen</label>
+        <label for="promoChoice1">Queen </label>
 
         <input type="radio" id="promoChoice2"
          name="contact" value="Rook">

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -20,21 +20,21 @@
 
           <% if row_number.odd? %>
             <% if index.even? %>
-              <td class="black tile droppable draggable" data-position_x=<%= index+1 %> data-position_y=<%= row_number %> data-piece-id= <%= piece ? piece.id : nil %>>
+              <td class="black tile droppable draggable" data-position_x=<%= index+1 %> data-position_y=<%= row_number %> data-piece-id= <%= piece ? piece.id : nil %> data-type=<%= piece ? piece.type : nil %>>
                 <%= check_piece(index + 1, row_number) %>
               </td>
             <% else %>
-              <td class="white tile droppable draggable "  data-position_x=<%= index+1 %> data-position_y=<%= row_number %> data-piece-id= <%= piece ? piece.id : nil %>>
+              <td class="white tile droppable draggable "  data-position_x=<%= index+1 %> data-position_y=<%= row_number %> data-piece-id= <%= piece ? piece.id : nil %> data-type=<%= piece ? piece.type : nil %>>
                 <%= check_piece(index + 1, row_number) %>
               </td>
             <% end %>
           <% else %>
             <% if index.even? %>
-              <td class="white tile droppable draggable" data-position_x=<%= index+1 %> data-position_y=<%= row_number %> data-piece-id= <%= piece ? piece.id : nil %>>
+              <td class="white tile droppable draggable" data-position_x=<%= index+1 %> data-position_y=<%= row_number %> data-piece-id= <%= piece ? piece.id : nil %> data-type=<%= piece ? piece.type : nil %>>
                 <%= check_piece(index + 1, row_number) %>
               </td>
             <% else %>
-              <td class="black tile droppable draggable" data-position_x=<%= index+1 %> data-position_y=<%= row_number %> data-piece-id= <%= piece ? piece.id : nil %>>
+              <td class="black tile droppable draggable" data-position_x=<%= index+1 %> data-position_y=<%= row_number %> data-piece-id= <%= piece ? piece.id : nil %> data-type=<%= piece ? piece.type : nil %>>
                 <%= check_piece(index + 1, row_number) %>
               </td>
             <% end %>
@@ -55,27 +55,8 @@
   </div>
 <% end %>
 
-<div id="myModal" class="modal" method="post">
-  <div class="modal-content">
 
-    <span class="close">CLOSE</span>
-    <form id="myForm" action="#" > 
-
-      <input type="radio"  name="rtype" value="Rook"> Rook<br>
-      <input type="radio"  name="qtype" value="Queen"> Queen<br>
-      <input type="radio"  name="btype" value="Bishop"> Bishop <br>
-      <input type="radio"  name="ktype" value="Knight"> Knight <br>
-          <input type="submit" value="Submit">
-      Choose<input type="text" name="fname" value="Donald"><br>
-      Rook: <input type="text" name="fname" value="Duck"><br><br>
-     <button onclick="myFunction()">Promote!</button> 
-
-    </form>
-  </div>
-</div>
-
-
-<!--  <div id="myModal" class="modal" method="post">
+ <div id="myModal" class="modal" method="post">
   <div class="modal-content">
     <span class="close">CLOSE</span>
     <form id="myForm">
@@ -104,28 +85,28 @@
       </div>
     </form>
  </div>
-</div> -->
+</div>
 
 
-<pre id="log">
-</pre>
 
 
 <script>
-var form = document.querySelector("form");
-var log = document.querySelector("#log");
+// var form = document.querySelector("form");
+// var log = document.querySelector("#log");
+// var modal = document.getElementById('myModal');
 
-form.addEventListener("submit", function(event) {
-  var data = new FormData(form);
-  var output = "";
-  for (const entry of data) {
-    // output = entry[0] + "=" + entry[1] + "\r";
-    promo = entry[1];
-  };
-  console.log(promo);
-  log.innerText = output;
-  event.preventDefault();
-}, false);
+// form.addEventListener("submit", function(event) {
+//   var data = new FormData(form);
+//   var output = "";
+//   for (const entry of data) {
+//     // output = entry[0] + "=" + entry[1] + "\r";
+//     promo = entry[1];
+//   };
+//   console.log(promo);
+//   // log.innerText = output;
+//   event.preventDefault();
+//   modal.style.display = "none";
+// }, false);
 </script>
 
 

--- a/db/migrate/20171222123010_alter_piece_add_promo.rb
+++ b/db/migrate/20171222123010_alter_piece_add_promo.rb
@@ -1,0 +1,5 @@
+class AlterPieceAddPromo < ActiveRecord::Migration[5.0]
+  def change
+    add_column :pieces, :promo, :string, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171214124458) do
+ActiveRecord::Schema.define(version: 20171222123010) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,9 +27,10 @@ ActiveRecord::Schema.define(version: 20171214124458) do
     t.integer  "result"
     t.integer  "winner_id"
     t.integer  "loser_id"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
     t.boolean  "in_progress"
+    t.integer  "next_player_to_move_id"
     t.integer  "next_player_id"
   end
 
@@ -60,6 +61,7 @@ ActiveRecord::Schema.define(version: 20171214124458) do
     t.string   "type"
     t.string   "image"
     t.boolean  "moved",      default: false
+    t.string   "promo"
   end
 
   create_table "queens", force: :cascade do |t|

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -690,28 +690,66 @@ RSpec.describe Piece, type: :model do
 
 
   #tests for promotion
-  describe "promotion(x,y)" do
+  describe "promotion(x,y, 'Queen)" do
    it "should promote when the pawn reaches the oposite row if it is empty" do
      game = FactoryBot.create(:game)
      piece1 = Pawn.create(position_x: 1, position_y: 7, color: "white", game_id: game.id)
-     piece1.move_to!(1,8)
+     piece1.move_to!(1,8, "Queen")
      piece2 = game.pieces.where(position_x: 1, position_y: 8)[0]
  
      expect(piece2.type).to eq("Queen")
    end
   end
 
-  describe "promotion(x,y)" do
+  describe "promotion(x,y, 'Queen')" do
    it "should promote when the pawn reaches the oposite row if it is empty" do
      game = FactoryBot.create(:game)
      piece1 = Pawn.create(position_x: 1, position_y: 7, color: "white", game_id: game.id)
      piece2 = Bishop.create(position_x: 2, position_y: 8, color: "black", game_id: game.id)
-     piece1.move_to!(2,8)
+     piece1.move_to!(2,8, "Queen")
      piece3 = game.pieces.where(position_x: 2, position_y: 8)[0]
  
      expect(piece3.type).to eq("Queen")
    end
   end
+
+  describe "promotion(x,y, 'Rook')" do
+   it "should promote when the pawn reaches the oposite row if it is empty" do
+     game = FactoryBot.create(:game)
+     piece1 = Pawn.create(position_x: 1, position_y: 7, color: "white", game_id: game.id)
+     piece2 = Bishop.create(position_x: 2, position_y: 8, color: "black", game_id: game.id)
+     piece1.move_to!(2,8, "Rook")
+     piece3 = game.pieces.where(position_x: 2, position_y: 8)[0]
+ 
+     expect(piece3.type).to eq("Rook")
+   end
+  end
+
+    describe "promotion(x,y, 'Bishop')" do
+   it "should promote when the pawn reaches the oposite row if it is empty" do
+     game = FactoryBot.create(:game)
+     piece1 = Pawn.create(position_x: 1, position_y: 7, color: "white", game_id: game.id)
+     piece2 = Bishop.create(position_x: 2, position_y: 8, color: "black", game_id: game.id)
+     piece1.move_to!(2,8, 'Bishop')
+     piece3 = game.pieces.where(position_x: 2, position_y: 8)[0]
+ 
+     expect(piece3.type).to eq('Bishop')
+   end
+  end
+
+  describe "promotion(x,y, 'Knight')" do
+   it "should promote when the pawn reaches the oposite row if it is empty" do
+     game = FactoryBot.create(:game)
+     piece1 = Pawn.create(position_x: 1, position_y: 7, color: "white", game_id: game.id)
+     piece2 = Bishop.create(position_x: 2, position_y: 8, color: "black", game_id: game.id)
+     piece1.move_to!(2,8, 'Knight')
+     piece3 = game.pieces.where(position_x: 2, position_y: 8)[0]
+ 
+     expect(piece3.type).to eq('Knight')
+   end
+  end
+
+
 
 
   #tests for stalemate


### PR DESCRIPTION
- Added modal in view
- Added field "promo" to pieces, used only when listening to the submit event in JS, allows to pass the data to the update controller, then to the promote method, telling in what to promote. 
- Modified the move_to! to accept promo as a third argument, but this is completely transparent for the rest of the methods as the argument is optional.
- Fixed and added tests for promotion
- Fixed the issue with the bishop and the queen. The bug was in the "is_diagonally obstructed?", for some types of movements (x1 > x2, y1 < y2) and (x1 < x2, y1 > y2) it was creating a wrong array of squares to check, hence sometimes was finding an obstruction where there should not be, hence the feeling of randomness of the error...